### PR TITLE
Fix difference between planning and vision frames + some necessary changes

### DIFF
--- a/src/agimus_sot/task/pre_grasp.py
+++ b/src/agimus_sot/task/pre_grasp.py
@@ -69,8 +69,11 @@ class PreGrasp (Task):
 
     def makeTasks(self, sotrobot, withMeasurementOfObjectPos, withMeasurementOfGripperPos,
             withMeasurementOfOtherGripperPos = False, withDerivative = False):
-        if self.gripper.enabled:
-            if self.otherGripper is not None and self.otherGripper.enabled:
+        assert self.gripper.enabled
+        assert self.otherGripper is None or self.otherGripper.enabled
+
+        if self.gripper.controllable:
+            if self.otherGripper is not None and self.otherGripper.controllable:
                 self._makeRelativeTask (sotrobot,
                         withMeasurementOfObjectPos, withMeasurementOfGripperPos,
                         withMeasurementOfOtherGripperPos, withDerivative)
@@ -79,7 +82,12 @@ class PreGrasp (Task):
                         withMeasurementOfObjectPos, withMeasurementOfGripperPos,
                         withDerivative)
         else:
-            if self.otherGripper is not None and self.otherGripper.enabled:
+            if self.otherGripper is not None and self.otherGripper.controllable:
+                if self.handle.robotName != self.otherHandle.robotName and \
+                        self.gripper.robotName == self.otherHandle.robotName:
+                    # locally inverse the gripper and the handle
+                    print("swapping gripper {} and handle {}".format(self.gripper, self.handle))
+                    self.gripper, self.handle = self.handle, self.gripper
                 self._makeAbsoluteBasedOnOther (sotrobot,
                         withMeasurementOfObjectPos, withMeasurementOfGripperPos,
                         withMeasurementOfOtherGripperPos,

--- a/src/agimus_sot/task/pre_grasp_post_action.py
+++ b/src/agimus_sot/task/pre_grasp_post_action.py
@@ -52,12 +52,12 @@ class PreGraspPostAction (Task):
 
     # \param withDerivative not used. Kept for compatibility with other tasks.
     def makeTasks(self, sotrobot, withDerivative = False):
-        if self.gripper.enabled:
-            if self.otherGripper is not None and self.otherGripper.enabled:
+        if self.gripper.controllable:
+            if self.otherGripper is not None and self.otherGripper.controllable:
                 self._makeRelativeTask (sotrobot)
             else:
                 self._makeAbsoluteTask (sotrobot, self.gripper)
-        elif self.otherGripper is not None and self.otherGripper.enabled:
+        elif self.otherGripper is not None and self.otherGripper.controllable:
                 self._makeAbsoluteTask (sotrobot, self.otherGripper)
         else:
             # TODO Both grippers are disabled so nothing can be done...

--- a/src/agimus_sot/task/task.py
+++ b/src/agimus_sot/task/task.py
@@ -168,8 +168,7 @@ class Task(object):
     ## \return a 2-uplet:
     ##         - the If entity, whose signal sin1 (resp. boolSelection) should be
     ##           plugged to tf output signal (resp tf availability signal)
-    ##         - a tuple to be added to
-    ##           plugged to tf output signal (resp tf availability signal)
+    ##         - a tuple that should be passed to addTfListenerTopic
     def makeTfListenerDefaultValue (self, name, value, outputs = None):
         from dynamic_graph.sot.core.switch import SwitchMatrixHomogeneous as Switch
         from agimus_sot.tools import plugMatrixHomo, assertEntityDoesNotExist

--- a/src/agimus_sot/tools.py
+++ b/src/agimus_sot/tools.py
@@ -134,3 +134,38 @@ def matrixHomoInverse(name, valueOrSignal=None, check=True):
     ent = Inverse_of_matrixHomo (name)
     plugMatrixHomo(valueOrSignal, ent.sin)
     return ent
+
+class IfEntity:
+    def __init__ (self, switch):
+        self.switch = switch
+    @property
+    def condition(self): return self.switch.boolSelection
+    @property
+    def then_(self): return self.switch.sin1
+    @property
+    def else_(self): return self.switch.sin0
+    @property
+    def out(self): return self.switch.sout
+
+def entityIfMatrixHomo (name, condition, value_then, value_else, check=True):
+    """
+    - name: the If entity name,
+    - condition: None, a boolean constant or a boolean signal.
+    - value_then, value_else: None, a constant MatrixHomo or a MatrixHomo signal.
+    """
+    from dynamic_graph.sot.core.switch import SwitchMatrixHomogeneous as Switch
+    from agimus_sot.tools import plugMatrixHomo, assertEntityDoesNotExist
+    from dynamic_graph.signal_base import SignalBase
+    from dynamic_graph import plug
+    if check: assertEntityDoesNotExist(name)
+    switch = Switch(name)
+    switch.setSignalNumber(2)
+    if_ = IfEntity(switch)
+    if value_then is not None: plugMatrixHomo (value_then, if_.then_)
+    if value_else is not None: plugMatrixHomo (value_else, if_.else_)
+    if condition  is not None:
+        if isinstance(condition, bool):
+            if_.condition.value = condition
+        else:
+            plug (condition, if_.condition)
+    return if_


### PR DESCRIPTION
Those changes likely break the API. Now:
- the camera frame is obtained from *robot.camera_frame*
- the *robot.name* should match the one in HPP