### PR TITLE
[ObjectLocalization] Add a visual servoing mode

### DIFF
--- a/src/object-localization.cc
+++ b/src/object-localization.cc
@@ -65,7 +65,8 @@ ObjectLocalization::ObjectLocalization(const std::string& name) :
   cMoSOUT(boost::bind(&ObjectLocalization::compute_cMo, this, _1, _2),
 	  wMcSIN,
 	  "ObjectLocalization("+name+")::output(MatrixHomo)::cMo"),
-  doneSOUT("ObjectLocalization("+name+")::output(bool)::done")
+  doneSOUT("ObjectLocalization("+name+")::output(bool)::done"),
+  wMoInitialized_(false)
 {
   addCommands();
   doneSOUT.setConstant(false);
@@ -95,6 +96,11 @@ void ObjectLocalization::trigger(const int& t)
 MatrixHomogeneous& ObjectLocalization::compute_cMo
 (MatrixHomogeneous& res, int t)
 {
+  if(!wMoInitialized_){
+    throw std::runtime_error("ObjectLocalization::compute_cMo :"
+    " Position of object in world frame not intialized, please call"
+    " trigger. Make sure the signal \"done\" is true.");
+  }
   wMcSIN.recompute(t);
   MatrixHomogeneous cMw = wMcSIN.access(t).inverse();
   res = cMw * wMoSOUT.access(t);

--- a/src/object-localization.hh
+++ b/src/object-localization.hh
@@ -90,7 +90,11 @@ class AGIMUS_SOT_DLLAPI ObjectLocalization : public Entity
   void addCommands();
   MatrixHomogeneous& compute_cMo(MatrixHomogeneous& res, int t);
   void trigger(const int&);
+  void setVisualServoingMode(const bool& visualServoing){
+    visualServoingMode_ = visualServoing;
+  }
   bool wMoInitialized_;
+  bool visualServoingMode_;
 }; // class PartLocalization
 } // namespace agimus
 } // namespace dynamicgraph

--- a/src/object-localization.hh
+++ b/src/object-localization.hh
@@ -90,6 +90,7 @@ class AGIMUS_SOT_DLLAPI ObjectLocalization : public Entity
   void addCommands();
   MatrixHomogeneous& compute_cMo(MatrixHomogeneous& res, int t);
   void trigger(const int&);
+  bool wMoInitialized_;
 }; // class PartLocalization
 } // namespace agimus
 } // namespace dynamicgraph


### PR DESCRIPTION
  - Set to true by default, in visual servoing mode, the pose of
    the object is updated as often as possible.
  - And throw if object pose is not initialized.